### PR TITLE
Create workflow to send dispatch to website repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Dispatch to Website repo to trigger workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Dispatch Website repo
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.DISPATCH_WEBSITE_TOKEN }}" \
+          https://api.github.com/repos/remigourdon/website/dispatches \
+          -d '{"event_type":"til-update","client_payload":{}}'


### PR DESCRIPTION
This PR adds a workflow that will send a [repository_dispatch](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event) workflow event to the [Website repo](https://github.com/remigourdon/website) using the API and a fine-grained Personal Access Token scope to read/write [Contents](https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens#contents).